### PR TITLE
Bump actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/provider-compatibility.yml
+++ b/.github/workflows/provider-compatibility.yml
@@ -93,7 +93,7 @@ jobs:
                                                  -providers
         working-directory: ${{ matrix.release.dir }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.release.tgz }}
           path: ${{ matrix.release.tgz }}
@@ -177,7 +177,7 @@ jobs:
         run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
         working-directory: ${{ matrix.branch.dir }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.branch.tgz }}
           path: ${{ matrix.branch.tgz }}


### PR DESCRIPTION
## Summary

The `Provider compatibility across versions` workflow fails on every scheduled run with:

```
##[error]This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.
Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

GitHub deprecated `actions/upload-artifact@v3` and `actions/download-artifact@v3` on **April 16, 2024**, and configured them to **auto-fail at the platform level** regardless of what the workflow tries to do. Every matrix job in this workflow fails instantly, before any real work runs.

## Root cause

`.github/workflows/provider-compatibility.yml` pinned `actions/upload-artifact@v3` in two places (lines 96 and 180). `actions/download-artifact` in the same file is already at `@v4`, so only the two uploads were out of date.

## Fix

Bump both occurrences to `actions/upload-artifact@v4`:

```diff
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
```

`v4` is API-compatible with `v3` for the simple `name` + `path` usage in this workflow, so no other changes are needed. (For workflows that depend on multiple jobs downloading the *same* artifact name, `v4` requires unique names or the `merge-multiple` flag in `download-artifact` — not applicable here.)

## Test plan

- [ ] Merge this PR
- [ ] Trigger the `Provider compatibility across versions` workflow (or wait for the next scheduled run)
- [ ] Confirm all matrix jobs run past the `upload-artifact` step and complete end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)